### PR TITLE
docs: fix missing backslash in WasmEdge example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Llama-Nexus is a gateway service for managing and orchestrating LlamaEdge API se
     llama-api-server.wasm \
     --prompt-template llama-3-chat \
     --ctx-size 128000 \
-    --model-name Llama-3.2-3b
+    --model-name Llama-3.2-3b \
     --port 10010
   ```
 


### PR DESCRIPTION
Fixed missing backslash in the wasmedge startup command to ensure the entire command runs correctly as one shell command. [Register LlamaEdge API Servers to Llama-Nexus](https://github.com/LlamaEdge/llama-nexus?tab=readme-ov-file#installation)
