### PR TITLE
Add responses API endpoint 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "dotenv",
  "endpoints",
  "futures-util",
  "http",
@@ -24,6 +25,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmcp",
+ "rusqlite",
  "serde",
  "serde_json",
  "sqlx",
@@ -52,6 +54,18 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -791,6 +805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +937,18 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fdeflate"
@@ -1186,6 +1218,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1196,6 +1231,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2699,6 +2743,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.9.4",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3077,7 +3135,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "log",
  "memchr",
@@ -4439,7 +4497,7 @@ checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name    = "LlamaNexus"
 version = "0.8.2"
 edition = "2024"
 
+[[bin]]
+name = "llama-nexus"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.82"
@@ -10,9 +14,10 @@ axum = { version = "^0.8", features = ["tokio", "http2", "multipart"] }
 bitflags = "2.8.0"
 bytes = "1.10.1"
 chat-prompts = { version = "0.35.0" }
-chrono = "0.4.41"
+chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "^4.5", features = ["cargo", "derive"] }
 config = { version = "^0.15", features = ["toml"] }
+dotenv = "0.15"
 endpoints = { version = "0.35.0", features = ["whisper"] }
 futures-util = "0.3"
 http = "1.2"
@@ -29,6 +34,7 @@ rmcp = { version = "0.6.3", features = [
     "tower",
     "auth",
 ] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sqlx = { version = "0.8.6", features = ["sqlite", "chrono", "runtime-tokio"] }
@@ -41,7 +47,3 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.7.0", features = ["v4"] }
-
-[[bin]]
-name = "llama-nexus"
-path = "src/main.rs"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod handlers;
 mod info;
 mod mcp;
 mod memory;
+mod responses;
 mod server;
 mod utils;
 
@@ -69,6 +70,7 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> ServerResult<()> {
+    dotenv::dotenv().ok();
     // parse the command line arguments
     let cli = Cli::parse();
 
@@ -147,6 +149,13 @@ async fn main() -> ServerResult<()> {
 
     let state = Arc::new(state);
 
+    // Initialize responses database
+    let db = responses::Database::new("sessions.db").expect("Failed to initialize database");
+    let responses_state = Arc::new(responses::AppState {
+        db,
+        main_state: state.clone(),
+    });
+
     // Register servers defined in configuration file
     state.register_config_servers().await?;
 
@@ -162,8 +171,8 @@ async fn main() -> ServerResult<()> {
         .allow_headers(Any)
         .allow_origin(Any);
 
-    // Set up the router
-    let mut app = Router::new()
+    // Set up the main router
+    let mut main_router = Router::new()
         .route("/v1/chat/completions", post(handlers::chat_handler))
         .route("/v1/embeddings", post(handlers::embeddings_handler))
         .route(
@@ -195,7 +204,7 @@ async fn main() -> ServerResult<()> {
     // Add memory endpoints only if memory is enabled
     if state.memory.is_some() {
         dual_info!("Memory endpoints are enabled");
-        app = app
+        main_router = main_router
             .route(
                 "/v1/memory/conversations/{conv_id}/history",
                 get(handlers::get_conversation_history_handler),
@@ -212,8 +221,20 @@ async fn main() -> ServerResult<()> {
         dual_info!("Memory endpoints are disabled");
     }
 
+    // Add state to main router
+    let main_router = main_router.with_state(state.clone());
+
+    // Create responses router
+    let responses_router = Router::new()
+        .route("/v1/responses", post(responses::responses_handler))
+        .route("/health", get(responses::health_handler))
+        .with_state(responses_state);
+
     let app =
-        app.layer(cors)
+        Router::new()
+            .merge(main_router)
+            .merge(responses_router)
+            .layer(cors)
             .layer(TraceLayer::new_for_http())
             .layer(axum::middleware::from_fn(
                 |mut req: Request<Body>, next: axum::middleware::Next| async move {
@@ -241,8 +262,7 @@ async fn main() -> ServerResult<()> {
             ))
             .fallback_service(ServeDir::new(&cli.web_ui).not_found_service(
                 ServeDir::new(&cli.web_ui).append_index_html_on_directories(true),
-            ))
-            .with_state(state.clone());
+            ));
 
     // Create the listener
     let listener = tokio::net::TcpListener::bind(&addr).await.map_err(|e| {

--- a/src/responses/db.rs
+++ b/src/responses/db.rs
@@ -1,0 +1,291 @@
+use std::sync::Mutex;
+
+use rusqlite::{Connection, Result, params};
+
+use crate::responses::models::{Session, SessionRow};
+
+pub struct Database {
+    conn: Mutex<Connection>,
+}
+
+impl Database {
+    pub fn new(db_path: &str) -> Result<Self> {
+        let conn = Connection::open(db_path)?;
+        let db = Database {
+            conn: Mutex::new(conn),
+        };
+        db.create_tables()?;
+        Ok(db)
+    }
+
+    pub fn create_tables(&self) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS sessions(
+                id TEXT PRIMARY KEY,
+                session_data TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                last_updated INTEGER NOT NULL
+            )",
+            [],
+        )?;
+        Ok(())
+    }
+
+    pub fn save_session(&self, session: &Session) -> Result<()> {
+        let session_json = serde_json::to_string(session)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
+
+        let now = chrono::Utc::now().timestamp();
+        let conn = self.conn.lock().unwrap();
+
+        conn.execute(
+            "INSERT OR REPLACE INTO sessions (id, session_data, created_at, last_updated)
+            VALUES (?1, ?2, ?3, ?4)",
+            params![session.response_id, session_json, session.created, now],
+        )?;
+        Ok(())
+    }
+
+    #[allow(dead_code)] 
+    pub fn get_session(&self, session_id: &str) -> Result<Option<Session>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT session_data FROM sessions WHERE id = ?1")?;
+
+        let mut session_iter = stmt.query_map([session_id], |row| {
+            let session_data: String = row.get(0)?;
+            Ok(session_data)
+        })?;
+
+        if let Some(session_result) = session_iter.next() {
+            let session_data = session_result?;
+            let session: Session = serde_json::from_str(&session_data).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
+            return Ok(Some(session));
+        }
+
+        Ok(None)
+    }
+
+    pub fn find_session_by_response_id(&self, response_id: &str) -> Result<Option<Session>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT session_data FROM sessions")?;
+
+        let session_iter = stmt.query_map([], |row| {
+            let session_data: String = row.get(0)?;
+            Ok(session_data)
+        })?;
+
+        for session_result in session_iter {
+            let session_data = session_result?;
+            let session: Session = serde_json::from_str(&session_data).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    0,
+                    rusqlite::types::Type::Text,
+                    Box::new(e),
+                )
+            })?;
+
+            for message in session.messages.values() {
+                if let Some(msg_response_id) = &message.response_id
+                    && msg_response_id == response_id
+                {
+                    return Ok(Some(session));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
+    #[allow(dead_code)]
+    pub fn list_sessions(&self) -> Result<Vec<SessionRow>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, session_data, created_at, last_updated FROM sessions
+            ORDER BY last_updated DESC",
+        )?;
+
+        let session_iter = stmt.query_map([], |row| {
+            Ok(SessionRow {
+                id: row.get(0)?,
+                session_data: row.get(1)?,
+                created_at: row.get(2)?,
+                last_updated: row.get(3)?,
+            })
+        })?;
+
+        let mut sessions = Vec::new();
+        for session in session_iter {
+            sessions.push(session?);
+        }
+
+        Ok(sessions)
+    }
+
+    #[allow(dead_code)] 
+    pub fn delete_session(&self, session_id: &str) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute("DELETE FROM sessions WHERE id = ?1", params![session_id])?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::responses::models::Session;
+
+    fn create_test_database() -> Database {
+        Database::new(":memory:").expect("Failed to create test database")
+    }
+
+    fn create_test_session() -> Session {
+        let mut session = Session::new(
+            "test_session_123".to_string(),
+            "test_model".to_string(),
+            Some("You are a helpful assistant".to_string()),
+        );
+
+        session.add_message(
+            "user".to_string(),
+            "Hello, world!".to_string(),
+            10,
+            None,
+            None,
+        );
+
+        session.add_message(
+            "assistant".to_string(),
+            "Hello! How can I help you?".to_string(),
+            15,
+            Some(250),
+            Some("resp_456".to_string()),
+        );
+
+        session
+    }
+
+    #[test]
+    fn test_save_and_get_session() {
+        let db = create_test_database();
+        let session = create_test_session();
+        let session_id = session.response_id.clone();
+
+        let result = db.save_session(&session);
+        assert!(result.is_ok(), "Saving session should succeed");
+
+        let retrieved = db.get_session(&session_id).unwrap();
+        assert!(retrieved.is_some(), "Should find the saved session");
+
+        let retrieved_session = retrieved.unwrap();
+        assert_eq!(retrieved_session.response_id, session.response_id);
+        assert_eq!(retrieved_session.model_used, session.model_used);
+        assert_eq!(retrieved_session.messages.len(), session.messages.len());
+
+        let result = db.get_session("nonexistent_id").unwrap();
+        assert!(
+            result.is_none(),
+            "Should return None for nonexistent session"
+        );
+    }
+
+    #[test]
+    fn test_find_session_by_response_id() {
+        let db = create_test_database();
+        let session = create_test_session();
+
+        db.save_session(&session).unwrap();
+
+        let found = db.find_session_by_response_id("resp_456").unwrap();
+        assert!(
+            found.is_some(),
+            "Should find session by message response ID"
+        );
+
+        let found_session = found.unwrap();
+        assert_eq!(found_session.response_id, session.response_id);
+    }
+
+    #[test]
+    fn test_session_serialization_roundtrip() {
+        let db = create_test_database();
+        let original_session = create_test_session();
+
+        db.save_session(&original_session).unwrap();
+        let retrieved = db
+            .get_session(&original_session.response_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(retrieved.response_id, original_session.response_id);
+        assert_eq!(retrieved.model_used, original_session.model_used);
+        assert_eq!(retrieved.created, original_session.created);
+        assert_eq!(retrieved.messages.len(), original_session.messages.len());
+
+        let original_msg = original_session.messages.get("2").unwrap();
+        let retrieved_msg = retrieved.messages.get("2").unwrap();
+        assert_eq!(retrieved_msg.role, original_msg.role);
+        assert_eq!(retrieved_msg.content, original_msg.content);
+        assert_eq!(retrieved_msg.tokens, original_msg.tokens);
+        assert_eq!(retrieved_msg.response_id, original_msg.response_id);
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        use std::{sync::Arc, thread};
+
+        let db = Arc::new(create_test_database());
+        let mut handles = vec![];
+
+        for i in 0..10 {
+            let db_clone = Arc::clone(&db);
+            let handle = thread::spawn(move || {
+                let mut session = Session::new(
+                    format!("session_{}", i),
+                    "test_model".to_string(),
+                    Some("System prompt".to_string()),
+                );
+
+                session.add_message(
+                    "user".to_string(),
+                    format!("Message from thread {}", i),
+                    5,
+                    None,
+                    None,
+                );
+
+                session.add_message(
+                    "assistant".to_string(),
+                    format!("Response from thread {}", i),
+                    8,
+                    Some(100),
+                    Some(format!("resp_{}", i)),
+                );
+
+                db_clone.save_session(&session).unwrap();
+
+                let retrieved = db_clone.get_session(&session.response_id).unwrap();
+                assert!(retrieved.is_some());
+
+                let found = db_clone
+                    .find_session_by_response_id(&format!("resp_{}", i))
+                    .unwrap();
+                assert!(found.is_some());
+            });
+            handles.push(handle);
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let sessions = db.list_sessions().unwrap();
+        assert_eq!(sessions.len(), 10);
+    }
+}

--- a/src/responses/db.rs
+++ b/src/responses/db.rs
@@ -47,7 +47,7 @@ impl Database {
         Ok(())
     }
 
-    #[allow(dead_code)] 
+    #[allow(dead_code)]
     pub fn get_session(&self, session_id: &str) -> Result<Option<Session>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare("SELECT session_data FROM sessions WHERE id = ?1")?;
@@ -128,7 +128,7 @@ impl Database {
         Ok(sessions)
     }
 
-    #[allow(dead_code)] 
+    #[allow(dead_code)]
     pub fn delete_session(&self, session_id: &str) -> Result<()> {
         let conn = self.conn.lock().unwrap();
         conn.execute("DELETE FROM sessions WHERE id = ?1", params![session_id])?;

--- a/src/responses/handlers.rs
+++ b/src/responses/handlers.rs
@@ -33,13 +33,13 @@ pub async fn responses_handler(
             Ok(None) => {
                 return Err((
                     StatusCode::BAD_REQUEST,
-                    format!("Previous response ID not found: {}", prev_id),
+                    format!("Previous response ID not found: {prev_id}"),
                 ));
             }
             Err(e) => {
                 return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Database error: {}", e),
+                    format!("Database error: {e}"),
                 ));
             }
         }
@@ -94,7 +94,7 @@ pub async fn responses_handler(
         Err(e) => {
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Chat backend error: {}", e),
+                format!("Chat backend error: {e}"),
             ));
         }
     };
@@ -113,7 +113,7 @@ pub async fn responses_handler(
     if let Err(e) = state.db.save_session(&session) {
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to save session: {}", e),
+            format!("Failed to save session: {e}"),
         ));
     }
 
@@ -145,7 +145,7 @@ async fn call_chat_backend(
 
     let target_server = match chat_servers.next().await {
         Ok(server) => server,
-        Err(e) => return Err(format!("Failed to get chat server: {}", e)),
+        Err(e) => return Err(format!("Failed to get chat server: {e}")),
     };
 
     let url = format!(
@@ -160,20 +160,20 @@ async fn call_chat_backend(
         .json(&request)
         .send()
         .await
-        .map_err(|e| format!("Request failed: {}", e))?;
+        .map_err(|e| format!("Request failed: {e}"))?;
 
     if !response.status().is_success() {
         let error_text = response
             .text()
             .await
             .unwrap_or_else(|_| "Unknown error".to_string());
-        return Err(format!("Chat API Error: {}", error_text));
+        return Err(format!("Chat API Error: {error_text}"));
     }
 
     let chat_response: endpoints::chat::ChatCompletionObject = response
         .json()
         .await
-        .map_err(|e| format!("Failed to parse response: {}", e))?;
+        .map_err(|e| format!("Failed to parse response: {e}"))?;
 
     let text = chat_response
         .choices
@@ -184,7 +184,6 @@ async fn call_chat_backend(
 
     Ok(text)
 }
-
 
 pub async fn health_handler() -> Json<serde_json::Value> {
     Json(serde_json::json!({

--- a/src/responses/handlers.rs
+++ b/src/responses/handlers.rs
@@ -1,0 +1,223 @@
+use std::sync::Arc;
+
+use axum::{extract::State, http::StatusCode, response::Json};
+use endpoints::chat::{
+    ChatCompletionRequest, ChatCompletionRequestMessage, ChatCompletionUserMessageContent,
+};
+
+use crate::{
+    AppState as MainAppState,
+    responses::{
+        db::Database,
+        models::{ResponseReply, ResponseRequest, Session},
+    },
+    server::RoutingPolicy,
+};
+
+pub struct AppState {
+    pub db: Database,
+    pub main_state: Arc<MainAppState>,
+}
+
+pub async fn responses_handler(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<ResponseRequest>,
+) -> Result<Json<ResponseReply>, (StatusCode, String)> {
+    let model = req.model.clone();
+
+    let response_id = format!("resp_{}", uuid::Uuid::new_v4().simple());
+
+    let mut session = if let Some(prev_id) = &req.previous_response_id {
+        match state.db.find_session_by_response_id(prev_id) {
+            Ok(Some(existing_session)) => existing_session,
+            Ok(None) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("Previous response ID not found: {}", prev_id),
+                ));
+            }
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Database error: {}", e),
+                ));
+            }
+        }
+    } else {
+        Session::new(response_id.clone(), model.clone(), req.instructions)
+    };
+
+    let user_tokens = estimate_tokens(&req.input);
+    session.add_message(
+        "user".to_string(),
+        req.input.clone(),
+        user_tokens,
+        None,
+        None,
+    );
+
+    let conversation = session.get_conversation_history();
+
+    let mut messages = Vec::new();
+    for (role, content) in conversation {
+        match role.as_str() {
+            "system" => {
+                let system_msg = ChatCompletionRequestMessage::new_system_message(content, None);
+                messages.push(system_msg);
+            }
+            "user" => {
+                let user_msg = ChatCompletionRequestMessage::new_user_message(
+                    ChatCompletionUserMessageContent::Text(content),
+                    None,
+                );
+                messages.push(user_msg);
+            }
+            "assistant" => {
+                let assistant_msg =
+                    ChatCompletionRequestMessage::new_assistant_message(Some(content), None, None);
+                messages.push(assistant_msg);
+            }
+            _ => {}
+        }
+    }
+
+    let chat_request = ChatCompletionRequest {
+        model: Some(model.clone()),
+        messages,
+        user: Some("responses-api".to_string()),
+        stream: Some(false),
+        ..Default::default()
+    };
+
+    let chat_result = match call_chat_backend(&state.main_state, chat_request).await {
+        Ok(result) => result,
+        Err(e) => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Chat backend error: {}", e),
+            ));
+        }
+    };
+
+    let output_tokens = estimate_tokens(&chat_result);
+    session.add_message(
+        "assistant".to_string(),
+        chat_result.clone(),
+        output_tokens,
+        None,
+        Some(response_id.clone()),
+    );
+
+    let final_result = chat_result;
+
+    if let Err(e) = state.db.save_session(&session) {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to save session: {}", e),
+        ));
+    }
+
+    let response = ResponseReply::new(
+        response_id,
+        model,
+        final_result,
+        user_tokens,
+        output_tokens,
+        req.previous_response_id,
+    );
+
+    Ok(Json(response))
+}
+
+fn estimate_tokens(text: &str) -> i32 {
+    (text.len() as f32 / 4.0).ceil() as i32
+}
+
+async fn call_chat_backend(
+    main_state: &Arc<MainAppState>,
+    request: ChatCompletionRequest,
+) -> Result<String, String> {
+    let servers = main_state.server_group.read().await;
+    let chat_servers = match servers.get(&crate::server::ServerKind::chat) {
+        Some(servers) => servers,
+        None => return Err("No chat server available".to_string()),
+    };
+
+    let target_server = match chat_servers.next().await {
+        Ok(server) => server,
+        Err(e) => return Err(format!("Failed to get chat server: {}", e)),
+    };
+
+    let url = format!(
+        "{}/chat/completions",
+        target_server.url.trim_end_matches('/')
+    );
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("Request failed: {}", e))?;
+
+    if !response.status().is_success() {
+        let error_text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Unknown error".to_string());
+        return Err(format!("Chat API Error: {}", error_text));
+    }
+
+    let chat_response: endpoints::chat::ChatCompletionObject = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    let text = chat_response
+        .choices
+        .first()
+        .and_then(|choice| choice.message.content.as_ref())
+        .map(|content| content.to_string())
+        .unwrap_or_else(|| "No response content".to_string());
+
+    Ok(text)
+}
+
+
+pub async fn health_handler() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "status": "ok",
+        "service": "responses-api"
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_estimate_tokens() {
+        assert_eq!(estimate_tokens(""), 0);
+
+        assert_eq!(estimate_tokens("a"), 1);
+
+        assert_eq!(estimate_tokens("test"), 1);
+        assert_eq!(estimate_tokens("hello"), 2);
+
+        assert_eq!(estimate_tokens("This is a test message"), 6);
+
+        assert_eq!(estimate_tokens("Hello, world!"), 4);
+    }
+
+    #[test]
+    fn test_health_handler() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let response = runtime.block_on(health_handler());
+
+        let json_value = response.0;
+        assert_eq!(json_value["status"], "ok");
+        assert_eq!(json_value["service"], "responses-api");
+    }
+}

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -1,0 +1,8 @@
+pub mod db;
+pub mod handlers;
+pub mod models;
+
+pub use db::Database;
+pub use handlers::{AppState, health_handler, responses_handler};
+#[allow(unused_imports)] // These are part of the public API and used in handlers
+pub use models::{ResponseReply, ResponseRequest, Session};

--- a/src/responses/models.rs
+++ b/src/responses/models.rs
@@ -1,0 +1,305 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct ResponseRequest {
+    pub model: String,
+    pub input: String,
+    pub instructions: Option<String>,
+    pub previous_response_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ResponseReply {
+    pub id: String,
+    pub object: String,
+    pub created_at: i64,
+    pub status: String,
+    pub model: String,
+    pub output: Vec<OutputItem>,
+    pub usage: Usage,
+    pub previous_response_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OutputItem {
+    #[serde(rename = "type")]
+    pub item_type: String,
+    pub id: String,
+    pub status: String,
+    pub role: String,
+    pub content: Vec<ContentItem>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContentItem {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    pub text: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Usage {
+    pub input_tokens: i32,
+    pub output_tokens: i32,
+    pub total_tokens: i32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Session {
+    pub response_id: String,
+    pub created: i64,
+    pub model_used: String,
+    pub messages: HashMap<String, SessionMessage>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionMessage {
+    pub role: String,
+    pub content: String,
+    pub tokens: i32,
+    pub created_at: i64,
+    pub response_time: Option<i64>,
+    pub response_id: Option<String>,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct SessionRow {
+    pub id: String,
+    pub session_data: String,
+    pub created_at: i64,
+    pub last_updated: i64,
+}
+
+impl Session {
+    pub fn new(response_id: String, model: String, instructions: Option<String>) -> Self {
+        let now = chrono::Utc::now().timestamp();
+        let mut messages = HashMap::new();
+
+        if let Some(inst) = instructions {
+            messages.insert(
+                "0".to_string(),
+                SessionMessage {
+                    role: "system".to_string(),
+                    content: inst,
+                    tokens: 0,
+                    created_at: now,
+                    response_time: None,
+                    response_id: None,
+                },
+            );
+        }
+
+        Session {
+            response_id,
+            created: now,
+            model_used: model,
+            messages,
+        }
+    }
+
+    pub fn add_message(
+        &mut self,
+        role: String,
+        content: String,
+        tokens: i32,
+        response_time: Option<i64>,
+        response_id: Option<String>,
+    ) {
+        let now = chrono::Utc::now().timestamp();
+        let index = self.messages.len().to_string();
+
+        self.messages.insert(
+            index,
+            SessionMessage {
+                role,
+                content,
+                tokens,
+                created_at: now,
+                response_time,
+                response_id,
+            },
+        );
+    }
+
+    pub fn get_conversation_history(&self) -> Vec<(String, String)> {
+        let mut history = Vec::new();
+
+        for i in 0..self.messages.len() {
+            let key = i.to_string();
+            if let Some(msg) = self.messages.get(&key) {
+                history.push((msg.role.clone(), msg.content.clone()));
+            }
+        }
+
+        history
+    }
+
+    #[allow(dead_code)]
+    pub fn total_tokens(&self) -> i32 {
+        self.messages.values().map(|msg| msg.tokens).sum()
+    }
+}
+
+impl ResponseReply {
+    pub fn new(
+        response_id: String,
+        model: String,
+        content: String,
+        input_tokens: i32,
+        output_tokens: i32,
+        previous_id: Option<String>,
+    ) -> Self {
+        let now = chrono::Utc::now().timestamp();
+        let message_id = format!("msg_{}", uuid::Uuid::new_v4().simple());
+
+        ResponseReply {
+            id: response_id,
+            object: "response".to_string(),
+            created_at: now,
+            status: "completed".to_string(),
+            model,
+            output: vec![OutputItem {
+                item_type: "message".to_string(),
+                id: message_id,
+                status: "completed".to_string(),
+                role: "assistant".to_string(),
+                content: vec![ContentItem {
+                    content_type: "output_text".to_string(),
+                    text: content,
+                }],
+            }],
+
+            usage: Usage {
+                input_tokens,
+                output_tokens,
+                total_tokens: input_tokens + output_tokens,
+            },
+            previous_response_id: previous_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_add_message() {
+        let mut session = Session::new("test_id".to_string(), "test_model".to_string(), None);
+
+        session.add_message("user".to_string(), "Hello!".to_string(), 5, None, None);
+
+        assert_eq!(session.messages.len(), 1);
+        let message = session.messages.get("0").unwrap();
+        assert_eq!(message.role, "user");
+        assert_eq!(message.content, "Hello!");
+        assert_eq!(message.tokens, 5);
+        assert!(message.response_id.is_none());
+
+        session.add_message(
+            "assistant".to_string(),
+            "Hi there!".to_string(),
+            10,
+            Some(150),
+            Some("resp_123".to_string()),
+        );
+
+        assert_eq!(session.messages.len(), 2);
+        let assistant_msg = session.messages.get("1").unwrap();
+        assert_eq!(assistant_msg.role, "assistant");
+        assert_eq!(assistant_msg.content, "Hi there!");
+        assert_eq!(assistant_msg.tokens, 10);
+        assert_eq!(assistant_msg.response_time, Some(150));
+        assert_eq!(assistant_msg.response_id, Some("resp_123".to_string()));
+    }
+
+    #[test]
+    fn test_session_get_conversation_history() {
+        let mut session = Session::new(
+            "test_id".to_string(),
+            "test_model".to_string(),
+            Some("System prompt".to_string()),
+        );
+
+        session.add_message(
+            "user".to_string(),
+            "First message".to_string(),
+            5,
+            None,
+            None,
+        );
+        session.add_message(
+            "assistant".to_string(),
+            "First response".to_string(),
+            8,
+            None,
+            None,
+        );
+        session.add_message(
+            "user".to_string(),
+            "Second message".to_string(),
+            6,
+            None,
+            None,
+        );
+
+        let history = session.get_conversation_history();
+
+        assert_eq!(history.len(), 4);
+        assert_eq!(
+            history[0],
+            ("system".to_string(), "System prompt".to_string())
+        );
+        assert_eq!(
+            history[1],
+            ("user".to_string(), "First message".to_string())
+        );
+        assert_eq!(
+            history[2],
+            ("assistant".to_string(), "First response".to_string())
+        );
+        assert_eq!(
+            history[3],
+            ("user".to_string(), "Second message".to_string())
+        );
+    }
+
+    #[test]
+    fn test_response_reply_new() {
+        let response = ResponseReply::new(
+            "resp_123".to_string(),
+            "test_model".to_string(),
+            "Hello, world!".to_string(),
+            10,
+            15,
+            Some("prev_resp_456".to_string()),
+        );
+
+        assert_eq!(response.id, "resp_123");
+        assert_eq!(response.object, "response");
+        assert_eq!(response.status, "completed");
+        assert_eq!(response.model, "test_model");
+        assert_eq!(
+            response.previous_response_id,
+            Some("prev_resp_456".to_string())
+        );
+
+        assert_eq!(response.usage.input_tokens, 10);
+        assert_eq!(response.usage.output_tokens, 15);
+        assert_eq!(response.usage.total_tokens, 25);
+
+        assert_eq!(response.output.len(), 1);
+        let output_item = &response.output[0];
+        assert_eq!(output_item.item_type, "message");
+        assert_eq!(output_item.status, "completed");
+        assert_eq!(output_item.role, "assistant");
+
+        assert_eq!(output_item.content.len(), 1);
+        let content_item = &output_item.content[0];
+        assert_eq!(content_item.content_type, "output_text");
+        assert_eq!(content_item.text, "Hello, world!");
+    }
+}


### PR DESCRIPTION
## Summary
- [x] Add /v1/responses/ POST endpoint for handling response requests
- [x] Add /health GET endpoint for health checks
- [x] Add session management with SQLite persistence
- [x] Add tests for responses

## Test Plan
  - Service startup
  - Health endpoint 
  - New conversation creation
  - Session continuation with context retention (stateful nature of endpoint)
  - Error handling for invalid inputs
  - Correct response structure validation

Related to WasmEdge/WasmEdge#4374