### PR TITLE
responses field expansion for ResponseRequest and ResponseReply

### DIFF
--- a/src/responses/handlers.rs
+++ b/src/responses/handlers.rs
@@ -291,11 +291,15 @@ fn validate_request(req: &ResponseRequest) -> Result<Vec<String>, ResponseError>
     }
 
     if req.modalities.is_some() {
-        warnings.push("Multiple modalities not yet fully supported".to_string());
+        warnings.push(
+            "`modalities` ignored: current backend only exposes `/chat/completions`; full Responses support will enable this field.".to_string(),
+        );
     }
 
     if req.reasoning.is_some() {
-        warnings.push("Reasoning enhancements not yet supported by backend".to_string());
+        warnings.push(
+            "`reasoning` ignored: current backend only exposes `/chat/completions`; full Responses support will enable this field.".to_string(),
+        );
     }
 
     if req.response_format.is_some() {
@@ -303,11 +307,27 @@ fn validate_request(req: &ResponseRequest) -> Result<Vec<String>, ResponseError>
     }
 
     if req.tool_resources.is_some() {
-        warnings.push("Tool resources not yet fully supported".to_string());
+        warnings.push(
+            "`tool_resources` ignored: current backend only exposes `/chat/completions`; full Responses support will enable this field.".to_string(),
+        );
     }
 
     if req.attachments.is_some() {
-        warnings.push("Attachments not yet fully supported".to_string());
+        warnings.push(
+            "`attachments` ignored: current backend only exposes `/chat/completions`; full Responses support will enable this field.".to_string(),
+        );
+    }
+
+    if req.metadata.is_some() {
+        warnings.push(
+            "`metadata` ignored: current backend only exposes `/chat/completions`; full Responses support will enable this field.".to_string(),
+        );
+    }
+
+    if req.include.is_some() {
+        warnings.push(
+            "`include` ignored: current backend only exposes `/chat/completions`; full Responses support will enable this field.".to_string(),
+        );
     }
 
     Ok(warnings)

--- a/src/responses/handlers.rs
+++ b/src/responses/handlers.rs
@@ -179,7 +179,10 @@ async fn responses_handler_impl(
         chat_request.top_p = Some(top_p.into());
     }
     if let Some(max_tokens) = req.max_output_tokens {
-        chat_request.max_completion_tokens = Some(max_tokens as i32);
+        chat_request.max_completion_tokens = Some(max_tokens.try_into().unwrap_or_else(|_| {
+            warnings.push("max_output_tokens exceeds i32::MAX, clamping to maximum".to_string());
+            i32::MAX
+        }));
     }
 
     if let Some(user_tools) = &req.tools

--- a/src/responses/handlers.rs
+++ b/src/responses/handlers.rs
@@ -185,10 +185,31 @@ async fn responses_handler_impl(
         }));
     }
 
+    let mcp_tool_names: Vec<String> = {
+        let config_guard = state.main_state.config.read().await;
+        config_guard
+            .mcp
+            .as_ref()
+            .map(|mcp| {
+                mcp.server
+                    .tool_servers
+                    .iter()
+                    .flat_map(|server| {
+                        server
+                            .tools
+                            .as_ref()
+                            .into_iter()
+                            .flatten()
+                            .map(|tool| tool.name.to_string())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+
     if let Some(user_tools) = &req.tools
         && !user_tools.is_empty()
     {
-        let mcp_tool_names: Vec<String> = Vec::new();
         let tool_warnings = check_tool_conflicts(&req, &mcp_tool_names)?;
         warnings.extend(tool_warnings);
 

--- a/src/responses/models.rs
+++ b/src/responses/models.rs
@@ -2,12 +2,140 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(tag = "type")]
+pub enum ResponseFormat {
+    #[serde(rename = "text")]
+    #[default]
+    Text,
+    #[serde(rename = "json_object")]
+    JsonObject,
+    #[serde(rename = "json_schema")]
+    JsonSchema { json_schema: JsonSchemaDefinition },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonSchemaDefinition {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub schema: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReasoningSettings {
+    pub effort: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    #[serde(rename = "type")]
+    pub tool_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<ToolFunction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolFunction {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ToolChoice {
+    String(String),
+    Object(ToolChoiceObject),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolChoiceObject {
+    #[serde(rename = "type")]
+    pub choice_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub function: Option<ToolChoiceFunction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolChoiceFunction {
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResources {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_interpreter: Option<CodeInterpreterResources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_search: Option<FileSearchResources>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeInterpreterResources {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<CodeInterpreterSandbox>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CodeInterpreterSandbox {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileSearchResources {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_store_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub files: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Attachment {
+    pub file_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorObject {
+    #[serde(rename = "type")]
+    pub error_type: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub param: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct ResponseRequest {
     pub model: String,
     pub input: String,
     pub instructions: Option<String>,
     pub previous_response_id: Option<String>,
+
+    pub modalities: Option<Vec<String>>,
+    pub response_format: Option<ResponseFormat>,
+    pub reasoning: Option<ReasoningSettings>,
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub max_output_tokens: Option<u32>,
+    pub stream: Option<bool>,
+    #[allow(dead_code)]
+    pub include: Option<Vec<String>>,
+    pub tools: Option<Vec<ToolDefinition>>,
+    pub tool_choice: Option<ToolChoice>,
+    pub tool_resources: Option<ToolResources>,
+    pub attachments: Option<Vec<Attachment>>,
+    pub metadata: Option<HashMap<String, String>>,
+    pub user: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -20,6 +148,33 @@ pub struct ResponseReply {
     pub output: Vec<OutputItem>,
     pub usage: Usage,
     pub previous_response_id: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modalities: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_outputs: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_resources: Option<ToolResources>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<ErrorObject>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_details: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -52,6 +207,8 @@ pub struct Session {
     pub created: i64,
     pub model_used: String,
     pub messages: HashMap<String, SessionMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extended_data: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -97,6 +254,7 @@ impl Session {
             created: now,
             model_used: model,
             messages,
+            extended_data: None,
         }
     }
 
@@ -168,16 +326,29 @@ impl ResponseReply {
                 role: "assistant".to_string(),
                 content: vec![ContentItem {
                     content_type: "output_text".to_string(),
-                    text: content,
+                    text: content.clone(),
                 }],
             }],
-
             usage: Usage {
                 input_tokens,
                 output_tokens,
                 total_tokens: input_tokens + output_tokens,
             },
             previous_response_id: previous_id,
+
+            metadata: None,
+            instructions: None,
+            modalities: None,
+            response_format: None,
+            reasoning: None,
+            tool_calls: None,
+            tool_outputs: None,
+            tool_resources: None,
+            output_text: Some(content),
+            input: None,
+            error: None,
+            warnings: None,
+            usage_details: None,
         }
     }
 }

--- a/src/responses/models.rs
+++ b/src/responses/models.rs
@@ -287,7 +287,7 @@ pub struct Session {
     pub model_used: String,
     pub messages: HashMap<String, SessionMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub extended_data: Option<serde_json::Value>,
+    pub extended_data: Option<serde_json::Value>, // extra request data (metadata, attachments, tool resources)
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/responses/models.rs
+++ b/src/responses/models.rs
@@ -2,56 +2,78 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
+/// Specifies the format of the model's output
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(tag = "type")]
 pub enum ResponseFormat {
+    /// Plain text response (default)
     #[serde(rename = "text")]
     #[default]
     Text,
+    /// Valid JSON object
     #[serde(rename = "json_object")]
     JsonObject,
+    /// JSON conforming to a specific schema
     #[serde(rename = "json_schema")]
     JsonSchema { json_schema: JsonSchemaDefinition },
 }
 
+/// JSON schema definition for structured output
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonSchemaDefinition {
+    /// Name of the schema
     pub name: String,
+    /// Optional description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// JSON schema specification
     pub schema: serde_json::Value,
+    /// Whether to enforce strict adherence
     #[serde(skip_serializing_if = "Option::is_none")]
     pub strict: Option<bool>,
 }
 
+/// Settings for model reasoning enhancements
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReasoningSettings {
+    /// Reasoning effort level (e.g., "medium")
     pub effort: String,
+    /// Additional reasoning parameters
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+/// Definition of a tool that can be called by the model
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDefinition {
+    /// Type of tool (e.g., "function")
     #[serde(rename = "type")]
     pub tool_type: String,
+    /// Function definition if type is "function"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function: Option<ToolFunction>,
 }
 
+/// Function tool specification
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolFunction {
+    /// Function name
     pub name: String,
+    /// Function description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// JSON schema for function parameters
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<serde_json::Value>,
 }
 
+/// How the model should use tools
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ToolChoice {
+    /// String choice ("auto", "none")
     String(String),
+    /// Specific tool selection
     Object(ToolChoiceObject),
 }
 
@@ -68,10 +90,13 @@ pub struct ToolChoiceFunction {
     pub name: String,
 }
 
+/// Resources available to tools during execution
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResources {
+    /// Code interpreter sandbox resources
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code_interpreter: Option<CodeInterpreterResources>,
+    /// File search resources
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_search: Option<FileSearchResources>,
 }
@@ -96,83 +121,137 @@ pub struct FileSearchResources {
     pub files: Option<Vec<String>>,
 }
 
+/// File attachment for the request
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Attachment {
+    /// File identifier
     pub file_id: String,
+    /// Tools that can access this file
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<String>>,
 }
 
+/// Error information when request fails
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ErrorObject {
+    /// Error type classification
     #[serde(rename = "type")]
     pub error_type: String,
+    /// Human-readable error message
     pub message: String,
+    /// Parameter that caused the error
     #[serde(skip_serializing_if = "Option::is_none")]
     pub param: Option<String>,
+    /// Error code
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<String>,
 }
 
+/// Request to generate a response from a model
+///
+/// Implements the OpenAI Responses API specification
 #[derive(Debug, Deserialize)]
 pub struct ResponseRequest {
+    /// Model identifier
     pub model: String,
+    /// Input text to process
     pub input: String,
+    /// System instructions for the model
     pub instructions: Option<String>,
+    /// ID of previous response for conversation continuity
     pub previous_response_id: Option<String>,
 
+    /// Output modalities (e.g., ["text", "audio"])
     pub modalities: Option<Vec<String>>,
+    /// Format specification for the response
     pub response_format: Option<ResponseFormat>,
+    /// Reasoning enhancement settings
     pub reasoning: Option<ReasoningSettings>,
+    /// Sampling temperature (0.0-2.0)
     pub temperature: Option<f32>,
+    /// Nucleus sampling parameter (0.0-1.0)
     pub top_p: Option<f32>,
+    /// Maximum tokens to generate
     pub max_output_tokens: Option<u32>,
+    /// Enable streaming response
     pub stream: Option<bool>,
+    /// Additional response sections to include
     #[allow(dead_code)]
     pub include: Option<Vec<String>>,
+    /// Tool definitions available to the model
     pub tools: Option<Vec<ToolDefinition>>,
+    /// Tool selection strategy
     pub tool_choice: Option<ToolChoice>,
+    /// Resources available to tools
     pub tool_resources: Option<ToolResources>,
+    /// File attachments
     pub attachments: Option<Vec<Attachment>>,
+    /// User-defined metadata
     pub metadata: Option<HashMap<String, String>>,
+    /// End-user identifier
     pub user: Option<String>,
 }
 
+/// Response object from a model generation request
+///
+/// Implements the OpenAI Responses API specification at
+/// https://platform.openai.com/docs/api-reference/responses/object
 #[derive(Debug, Serialize)]
 pub struct ResponseReply {
+    /// Unique identifier for this response
     pub id: String,
+    /// Object type ("response")
     pub object: String,
+    /// Unix timestamp of creation
     pub created_at: i64,
+    /// Response status ("completed", "failed", etc.)
     pub status: String,
+    /// Model that generated the response
     pub model: String,
+    /// Generated output items
     pub output: Vec<OutputItem>,
+    /// Token usage information
     pub usage: Usage,
+    /// ID of the previous response in conversation
     pub previous_response_id: Option<String>,
 
+    /// Echoed metadata from request
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<HashMap<String, String>>,
+    /// System instructions used
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    /// Output modalities produced
     #[serde(skip_serializing_if = "Option::is_none")]
     pub modalities: Option<Vec<String>>,
+    /// Response format used
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_format: Option<ResponseFormat>,
+    /// Reasoning traces and metadata
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<serde_json::Value>,
+    /// Tool calls made by the model
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<serde_json::Value>,
+    /// Results from tool executions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_outputs: Option<serde_json::Value>,
+    /// Resources used by tools
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_resources: Option<ToolResources>,
+    /// Concatenated text output for convenience
     #[serde(skip_serializing_if = "Option::is_none")]
     pub output_text: Option<String>,
+    /// Normalized input data
     #[serde(skip_serializing_if = "Option::is_none")]
     pub input: Option<serde_json::Value>,
+    /// Error details if status is "failed"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<ErrorObject>,
+    /// Non-fatal warnings and notices
     #[serde(skip_serializing_if = "Option::is_none")]
     pub warnings: Option<Vec<String>>,
+    /// Detailed usage breakdown
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_details: Option<serde_json::Value>,
 }


### PR DESCRIPTION
This PR extends the fields supported in ResponseRequest and ResponseReply. More specifically,

ResponseRequest,
  - modalities - output stream types (text, audio)
  - response_format - output formatting (text, json_object, json_schema)
  - reasoning - model reasoning
  - temperature
  - top_p
  - max_output_tokens
  - stream (returns 400 - not implemented)
  - include
  - tools - user tool definitions
  - tool_choice
  - tool_resources
  - attachments
  - metadata
  - user

ResponseReply,
  - metadata - same as ResponseRequest echoed 
  - instructions
  - modalities - actual output types produced
  - response_format - used response format
  - reasoning - reasoning traces (flexible JSON)
  - tool_calls - tool invocations (flexible JSON)
  - tool_outputs - tool invocation results (flexible JSON)
  - tool_resources - attached resources
  - output_text
  - input
  - error
  - warnings
  - usage_details

Closes #6 
Related to WasmEdge/WasmEdge#4374