### PR TITLE
responses-code-interpreter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "async-trait",
  "axum",
  "bitflags 2.9.4",
+ "bollard",
  "bytes",
  "chat-prompts",
  "chrono",
@@ -349,6 +350,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bollard"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d41711ad46fda47cd701f6908e59d1bd6b9a2b7464c0d0aeab95c6d37096ff8a"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.45.0-rc.26.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7c5415e3a6bc6d3e99eff6268e488fd4ee25e7b28c10f08fa6760bd9de16e4"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
 ]
 
 [[package]]
@@ -751,6 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -833,7 +879,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c1e6f6391c40a3da28a1edfaf1eda695c21434eecbd24fd730c63b5661a915e"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.3",
  "serde",
  "serde_json",
  "url",
@@ -1171,7 +1217,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.11.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1187,6 +1233,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1338,6 +1390,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,6 +1443,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1569,6 +1651,17 @@ name = "imgref"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -2648,7 +2741,7 @@ dependencies = [
  "pin-project-lite",
  "reqwest",
  "rmcp-macros",
- "schemars",
+ "schemars 1.0.4",
  "serde",
  "serde_json",
  "sse-stream",
@@ -2786,6 +2879,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
@@ -2894,6 +2999,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,6 +3037,24 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.11.3",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
+ "serde_core",
+ "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -3086,7 +3220,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.11.3",
  "log",
  "memchr",
  "once_cell",
@@ -3598,7 +3732,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.11.3",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -4114,6 +4248,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4121,6 +4271,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 async-trait = "0.1.82"
 axum = { version = "^0.8", features = ["tokio", "http2", "multipart"] }
 bitflags = "2.8.0"
+bollard = "0.17"
 bytes = "1.10.1"
 chat-prompts = { version = "0.35.2" }
 chrono = { version = "0.4.41", features = ["serde"] }

--- a/config.toml
+++ b/config.toml
@@ -35,6 +35,17 @@ summarization_strategy = "Incremental"
 max_stored_messages = 20                         # Trigger summarization when message count reaches this limit
 summarize_threshold = 12                         # Base number for calculating minimum kept messages (kept = threshold/2)
 
+# Optional sandboxed code interpreter for responses API
+[code_interpreter]
+enable = true                                    # Enable/disable Docker-based interpreter
+docker_image = "python:3.11-slim"                # Container image used for execution
+execution_timeout_secs = 20                      # Max seconds a snippet is allowed to run
+memory_limit_mb = 512                            # Memory cap per sandbox (in MB)
+cpu_percent = 50                                 # CPU share limit per sandbox (0-100)
+max_sessions = 4                                 # Maximum simultaneous sandboxes kept alive
+idle_timeout_secs = 300                          # Stop idle sandboxes after this many seconds
+preload_packages = ["numpy", "pandas"]           # Optional packages installed when a sandbox boots
+
 
 # ============================================================================
 # SECTION 2: AI SERVICE CONFIGURATION

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,8 @@ pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<MemoryConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub code_interpreter: Option<CodeInterpreterConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rag: Option<RagConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub server_info_push_url: Option<String>,
@@ -96,6 +98,7 @@ impl Default for Config {
             chat: None,
             embedding: None,
             memory: None,
+            code_interpreter: None,
             rag: None,
             server_info_push_url: None,
             server_health_push_url: None,
@@ -234,6 +237,51 @@ impl Default for MemoryConfig {
             summary_service_base_url: "http://localhost:10086/v1".to_string(),
             summary_service_api_key: String::new(),
         }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CodeInterpreterConfig {
+    pub enable: bool,
+    #[serde(default = "CodeInterpreterConfig::default_docker_image")]
+    pub docker_image: String,
+    #[serde(default = "CodeInterpreterConfig::default_timeout")]
+    pub execution_timeout_secs: u64,
+    #[serde(default = "CodeInterpreterConfig::default_memory")]
+    pub memory_limit_mb: u64,
+    #[serde(default = "CodeInterpreterConfig::default_cpu_percent")]
+    pub cpu_percent: u64,
+    #[serde(default = "CodeInterpreterConfig::default_max_sessions")]
+    pub max_sessions: usize,
+    #[serde(default = "CodeInterpreterConfig::default_idle_timeout")]
+    pub idle_timeout_secs: u64,
+    #[serde(default)]
+    pub preload_packages: Vec<String>,
+}
+
+impl CodeInterpreterConfig {
+    fn default_docker_image() -> String {
+        "python:3.11-slim".to_string()
+    }
+
+    const fn default_timeout() -> u64 {
+        20
+    }
+
+    const fn default_memory() -> u64 {
+        512
+    }
+
+    const fn default_cpu_percent() -> u64 {
+        50
+    }
+
+    const fn default_max_sessions() -> usize {
+        4
+    }
+
+    const fn default_idle_timeout() -> u64 {
+        300
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,7 @@ async fn main() -> ServerResult<()> {
 
     // Load the config based on the command
     let config = Config::load(&cli.config).await?;
+    let code_interpreter_config = config.code_interpreter.clone();
 
     // set the health check interval
     HEALTH_CHECK_INTERVAL
@@ -151,6 +152,21 @@ async fn main() -> ServerResult<()> {
     // Initialize application state
     let mut state = AppState::new(config, ServerInfo::default());
 
+    let interpreter = if let Some(ci_config) = code_interpreter_config.filter(|cfg| cfg.enable) {
+        match responses::code_interpreter::CodeInterpreterService::new(ci_config.into()).await {
+            Ok(service) => {
+                dual_info!("Code interpreter enabled");
+                Some(Arc::new(service))
+            }
+            Err(err) => {
+                dual_error!("Failed to initialize code interpreter: {err}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // Attach memory system to state
     if let Some(memory_system) = memory {
         state = state.with_memory(memory_system);
@@ -161,7 +177,11 @@ async fn main() -> ServerResult<()> {
     // Initialize responses state with lazy database initialization
     let db_path =
         std::env::var("NEXUS_RESPONSES_DB_PATH").unwrap_or_else(|_| "sessions.db".to_string());
-    let responses_state = Arc::new(responses::ResponsesAppState::new(db_path, state.clone()));
+    let responses_state = Arc::new(responses::ResponsesAppState::new(
+        db_path,
+        state.clone(),
+        interpreter.clone(),
+    ));
 
     // Register servers defined in configuration file
     state.register_config_servers().await?;

--- a/src/responses/code_interpreter/mod.rs
+++ b/src/responses/code_interpreter/mod.rs
@@ -1,0 +1,3 @@
+mod service;
+
+pub use service::{CodeInterpreterService, ExecutionResult};

--- a/src/responses/code_interpreter/service.rs
+++ b/src/responses/code_interpreter/service.rs
@@ -1,0 +1,342 @@
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use bollard::{
+    Docker,
+    container::{
+        Config as ContainerConfig, CreateContainerOptions, KillContainerOptions,
+        StartContainerOptions,
+    },
+    exec::{CreateExecOptions, StartExecOptions, StartExecResults},
+    models::HostConfig,
+};
+use futures_util::StreamExt;
+use thiserror::Error;
+use tokio::{
+    sync::{Mutex, OwnedSemaphorePermit, Semaphore},
+    time::timeout,
+};
+use tracing::{debug, warn};
+
+use crate::config::CodeInterpreterConfig;
+
+#[derive(Debug, Clone)]
+pub struct CodeInterpreterSettings {
+    pub docker_image: String,
+    pub execution_timeout: Duration,
+    pub memory_limit_mb: u64,
+    pub cpu_percent: u64,
+    pub max_sessions: usize,
+    pub idle_timeout: Duration,
+    pub preload_packages: Vec<String>,
+}
+
+impl From<CodeInterpreterConfig> for CodeInterpreterSettings {
+    fn from(config: CodeInterpreterConfig) -> Self {
+        Self {
+            docker_image: config.docker_image,
+            execution_timeout: Duration::from_secs(config.execution_timeout_secs.max(1)),
+            memory_limit_mb: config.memory_limit_mb.max(64),
+            cpu_percent: config.cpu_percent.clamp(1, 100),
+            max_sessions: config.max_sessions.max(1),
+            idle_timeout: if config.idle_timeout_secs == 0 {
+                Duration::ZERO
+            } else {
+                Duration::from_secs(config.idle_timeout_secs)
+            },
+            preload_packages: config.preload_packages,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecutionResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i64,
+}
+
+#[derive(Debug)]
+struct SandboxEntry {
+    container_id: String,
+    last_used: Instant,
+    _permit: OwnedSemaphorePermit,
+}
+
+#[derive(Debug, Error)]
+pub enum CodeInterpreterError {
+    #[error("Docker is unavailable: {0}")]
+    DockerUnavailable(String),
+    #[error("Failed to manage sandbox: {0}")]
+    Sandbox(String),
+    #[error("Failed to execute code: {0}")]
+    Execution(String),
+    #[error("Code execution timed out")]
+    Timeout,
+    #[error("Failed to acquire sandbox slot: {0}")]
+    Pool(String),
+}
+
+pub struct CodeInterpreterService {
+    docker: Docker,
+    settings: CodeInterpreterSettings,
+    sandboxes: Mutex<HashMap<String, SandboxEntry>>,
+    limiter: Arc<Semaphore>,
+}
+
+impl CodeInterpreterService {
+    pub async fn new(settings: CodeInterpreterSettings) -> Result<Self, CodeInterpreterError> {
+        let docker = Docker::connect_with_local_defaults()
+            .map_err(|err| CodeInterpreterError::DockerUnavailable(err.to_string()))?;
+
+        Ok(Self {
+            docker,
+            limiter: Arc::new(Semaphore::new(settings.max_sessions.max(1))),
+            sandboxes: Mutex::new(HashMap::new()),
+            settings,
+        })
+    }
+
+    pub async fn execute(
+        &self,
+        session_id: &str,
+        code: &str,
+    ) -> Result<ExecutionResult, CodeInterpreterError> {
+        self.reap_idle().await;
+
+        let container_id = self.ensure_sandbox(session_id).await?;
+        let result = self.exec_python(&container_id, code).await;
+        if result.is_err() {
+            self.teardown_session(session_id).await;
+        }
+        result
+    }
+
+    async fn ensure_sandbox(&self, session_id: &str) -> Result<String, CodeInterpreterError> {
+        if let Some(existing) = self
+            .sandboxes
+            .lock()
+            .await
+            .get_mut(session_id)
+            .map(|entry| {
+                entry.last_used = Instant::now();
+                entry.container_id.clone()
+            })
+        {
+            return Ok(existing);
+        }
+
+        let permit = self
+            .limiter
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|err| CodeInterpreterError::Pool(err.to_string()))?;
+
+        let container_id = match self.start_container(session_id).await {
+            Ok(id) => id,
+            Err(err) => {
+                drop(permit);
+                return Err(err);
+            }
+        };
+
+        let mut guard = self.sandboxes.lock().await;
+        guard.insert(
+            session_id.to_string(),
+            SandboxEntry {
+                container_id: container_id.clone(),
+                last_used: Instant::now(),
+                _permit: permit,
+            },
+        );
+        Ok(container_id)
+    }
+
+    async fn start_container(&self, session_id: &str) -> Result<String, CodeInterpreterError> {
+        let sandbox_name = format!("nexus-ci-{session_id}");
+
+        let host_config = HostConfig {
+            memory: Some((self.settings.memory_limit_mb * 1024 * 1024) as i64),
+            nano_cpus: Some(((self.settings.cpu_percent * 1_000_000_000) / 100) as i64),
+            network_mode: Some("none".to_string()),
+            auto_remove: Some(true),
+            ..Default::default()
+        };
+
+        let container_config = ContainerConfig {
+            image: Some(self.settings.docker_image.clone()),
+            cmd: Some(vec!["sleep".into(), "infinity".into()]),
+            working_dir: Some("/workspace".into()),
+            host_config: Some(host_config),
+            ..Default::default()
+        };
+
+        let container = self
+            .docker
+            .create_container(
+                Some(CreateContainerOptions::<String> {
+                    name: sandbox_name,
+                    platform: None,
+                }),
+                container_config,
+            )
+            .await
+            .map_err(|err| CodeInterpreterError::Sandbox(err.to_string()))?;
+
+        self.docker
+            .start_container(&container.id, None::<StartContainerOptions<String>>)
+            .await
+            .map_err(|err| CodeInterpreterError::Sandbox(err.to_string()))?;
+
+        if !self.settings.preload_packages.is_empty() {
+            let mut install_cmd = vec![
+                "pip".to_string(),
+                "install".to_string(),
+                "--no-cache-dir".to_string(),
+            ];
+            install_cmd.extend(self.settings.preload_packages.clone());
+            let _ = self
+                .run_exec(&container.id, install_cmd, Duration::from_secs(60))
+                .await;
+        }
+
+        Ok(container.id)
+    }
+
+    async fn exec_python(
+        &self,
+        container_id: &str,
+        code: &str,
+    ) -> Result<ExecutionResult, CodeInterpreterError> {
+        self.run_exec(
+            container_id,
+            vec!["python3".into(), "-u".into(), "-c".into(), code.to_string()],
+            self.settings.execution_timeout,
+        )
+        .await
+    }
+
+    async fn run_exec(
+        &self,
+        container_id: &str,
+        cmd: Vec<String>,
+        timeout_window: Duration,
+    ) -> Result<ExecutionResult, CodeInterpreterError> {
+        let exec = self
+            .docker
+            .create_exec(
+                container_id,
+                CreateExecOptions {
+                    attach_stdout: Some(true),
+                    attach_stderr: Some(true),
+                    cmd: Some(cmd),
+                    ..Default::default()
+                },
+            )
+            .await
+            .map_err(|err| CodeInterpreterError::Execution(err.to_string()))?;
+
+        let stream = self
+            .docker
+            .start_exec(
+                &exec.id,
+                Some(StartExecOptions {
+                    detach: false,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .map_err(|err| CodeInterpreterError::Execution(err.to_string()))?;
+
+        let collected = timeout(timeout_window, Self::collect_output(stream)).await;
+        let (stdout, stderr) = match collected {
+            Ok(result) => result?,
+            Err(_) => return Err(CodeInterpreterError::Timeout),
+        };
+
+        let inspect = self
+            .docker
+            .inspect_exec(&exec.id)
+            .await
+            .map_err(|err| CodeInterpreterError::Execution(err.to_string()))?;
+
+        let exit_code = inspect.exit_code.unwrap_or_default();
+
+        Ok(ExecutionResult {
+            stdout,
+            stderr,
+            exit_code,
+        })
+    }
+
+    async fn collect_output(
+        stream: StartExecResults,
+    ) -> Result<(String, String), CodeInterpreterError> {
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+
+        if let StartExecResults::Attached { mut output, .. } = stream {
+            while let Some(chunk) = output.next().await {
+                match chunk.map_err(|err| CodeInterpreterError::Execution(err.to_string()))? {
+                    bollard::container::LogOutput::StdOut { message } => {
+                        stdout.push_str(&String::from_utf8_lossy(&message));
+                    }
+                    bollard::container::LogOutput::StdErr { message } => {
+                        stderr.push_str(&String::from_utf8_lossy(&message));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok((stdout, stderr))
+    }
+
+    async fn reap_idle(&self) {
+        if self.settings.idle_timeout.is_zero() {
+            return;
+        }
+
+        let idle_limit = self.settings.idle_timeout;
+        let sessions: Vec<String> = self
+            .sandboxes
+            .lock()
+            .await
+            .iter()
+            .filter(|(_, entry)| entry.last_used.elapsed() >= idle_limit)
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+
+        for session_id in sessions {
+            debug!("Shutting down idle interpreter session {session_id}");
+            self.teardown_session(&session_id).await;
+        }
+    }
+
+    async fn teardown_session(&self, session_id: &str) {
+        let container_id = self
+            .sandboxes
+            .lock()
+            .await
+            .remove(session_id)
+            .map(|entry| entry.container_id);
+
+        if let Some(id) = container_id {
+            self.kill_container(&id).await;
+        }
+    }
+
+    async fn kill_container(&self, container_id: &str) {
+        if let Err(err) = self
+            .docker
+            .kill_container(container_id, None::<KillContainerOptions<String>>)
+            .await
+        {
+            warn!("Failed to stop interpreter container {container_id}: {err}");
+        }
+    }
+}

--- a/src/responses/db.rs
+++ b/src/responses/db.rs
@@ -64,7 +64,7 @@ impl Database {
             "INSERT OR REPLACE INTO sessions (id, session_data, created_at, last_updated)
             VALUES (?, ?, ?, ?)",
         )
-        .bind(&session.response_id)
+        .bind(&session.session_id)
         .bind(&session_json)
         .bind(session.created)
         .bind(now)
@@ -89,7 +89,7 @@ impl Database {
         }
     }
 
-    pub async fn find_session_by_response_id(
+    pub async fn find_session_by_backend_response_id(
         &self,
         response_id: &str,
     ) -> DBResult<Option<Session>> {
@@ -186,7 +186,7 @@ mod tests {
     async fn test_save_and_get_session() {
         let db = create_test_database().await;
         let session = create_test_session();
-        let session_id = session.response_id.clone();
+        let session_id = session.session_id.clone();
 
         let result = db.save_session(&session).await;
         assert!(result.is_ok(), "Saving session should succeed");
@@ -195,7 +195,7 @@ mod tests {
         assert!(retrieved.is_some(), "Should find the saved session");
 
         let retrieved_session = retrieved.unwrap();
-        assert_eq!(retrieved_session.response_id, session.response_id);
+        assert_eq!(retrieved_session.session_id, session.session_id);
         assert_eq!(retrieved_session.model_used, session.model_used);
         assert_eq!(retrieved_session.messages.len(), session.messages.len());
 
@@ -207,20 +207,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_find_session_by_response_id() {
+    async fn test_find_session_by_backend_response_id() {
         let db = create_test_database().await;
         let session = create_test_session();
 
         db.save_session(&session).await.unwrap();
 
-        let found = db.find_session_by_response_id("resp_456").await.unwrap();
+        let found = db
+            .find_session_by_backend_response_id("resp_456")
+            .await
+            .unwrap();
         assert!(
             found.is_some(),
             "Should find session by message response ID"
         );
 
         let found_session = found.unwrap();
-        assert_eq!(found_session.response_id, session.response_id);
+        assert_eq!(found_session.session_id, session.session_id);
     }
 
     #[tokio::test]
@@ -230,12 +233,12 @@ mod tests {
 
         db.save_session(&original_session).await.unwrap();
         let retrieved = db
-            .get_session(&original_session.response_id)
+            .get_session(&original_session.session_id)
             .await
             .unwrap()
             .unwrap();
 
-        assert_eq!(retrieved.response_id, original_session.response_id);
+        assert_eq!(retrieved.session_id, original_session.session_id);
         assert_eq!(retrieved.model_used, original_session.model_used);
         assert_eq!(retrieved.created, original_session.created);
         assert_eq!(retrieved.messages.len(), original_session.messages.len());
@@ -284,11 +287,11 @@ mod tests {
 
                 db_clone.save_session(&session).await.unwrap();
 
-                let retrieved = db_clone.get_session(&session.response_id).await.unwrap();
+                let retrieved = db_clone.get_session(&session.session_id).await.unwrap();
                 assert!(retrieved.is_some());
 
                 let found = db_clone
-                    .find_session_by_response_id(&format!("resp_{}", i))
+                    .find_session_by_backend_response_id(&format!("resp_{}", i))
                     .await
                     .unwrap();
                 assert!(found.is_some());

--- a/src/responses/handlers.rs
+++ b/src/responses/handlers.rs
@@ -2,10 +2,14 @@ use std::sync::Arc;
 
 use axum::{extract::State, http::StatusCode, response::Json};
 use tokio::sync::OnceCell;
+use uuid::Uuid;
+
+const INTERPRETER_OUTPUT_LIMIT: usize = 2000;
 
 use crate::{
     AppState as MainAppState,
     responses::{
+        code_interpreter::{CodeInterpreterService, ExecutionResult},
         db::{Database, DatabaseError},
         models::{
             Input, InputItem, InputMessageContent, ResponseItemInputMessageContent,
@@ -62,14 +66,20 @@ pub struct ResponsesAppState {
     db: OnceCell<Arc<Database>>,
     db_path: String,
     pub main_state: Arc<MainAppState>,
+    code_interpreter: Option<Arc<CodeInterpreterService>>,
 }
 
 impl ResponsesAppState {
-    pub fn new(db_path: String, main_state: Arc<MainAppState>) -> Self {
+    pub fn new(
+        db_path: String,
+        main_state: Arc<MainAppState>,
+        code_interpreter: Option<Arc<CodeInterpreterService>>,
+    ) -> Self {
         Self {
             db: OnceCell::new(),
             db_path,
             main_state,
+            code_interpreter,
         }
     }
 
@@ -80,6 +90,10 @@ impl ResponsesAppState {
             .await?;
 
         Ok(Arc::clone(db))
+    }
+
+    fn interpreter(&self) -> Option<Arc<CodeInterpreterService>> {
+        self.code_interpreter.as_ref().map(Arc::clone)
     }
 }
 
@@ -95,30 +109,43 @@ pub async fn responses_handler(
 
 async fn responses_handler_impl(
     state: Arc<ResponsesAppState>,
-    req: ResponseRequest,
+    mut req: ResponseRequest,
 ) -> Result<Json<ResponseReply>, ResponseError> {
+    let client_previous_response_id = req.upstream().previous_response_id.clone();
     let mut warnings = validate_request(&req)?;
 
     let db = state.get_or_create_db().await?;
 
-    let existing_session = if let Some(prev_id) = req.upstream().previous_response_id.as_ref() {
-        match db.find_session_by_response_id(prev_id).await? {
-            Some(session) => Some(session),
-            None => {
-                return Err(ResponseError::SessionNotFound(format!(
-                    "Previous response ID not found: {prev_id}"
-                )));
-            }
-        }
-    } else {
-        None
-    };
+    let mut existing_session = None;
+    let mut normalized_previous_backend_id = None;
+    let mut session_id = None;
 
+    if let Some(prev_id) = client_previous_response_id.clone() {
+        if let Some(session) = db.get_session(&prev_id).await? {
+            normalized_previous_backend_id = session.latest_backend_response_id();
+            session_id = Some(session.session_id.clone());
+            existing_session = Some(session);
+        } else if let Some(session) = db.find_session_by_backend_response_id(&prev_id).await? {
+            normalized_previous_backend_id = Some(prev_id.clone());
+            session_id = Some(session.session_id.clone());
+            existing_session = Some(session);
+        } else {
+            return Err(ResponseError::SessionNotFound(format!(
+                "Previous response ID not found: {prev_id}"
+            )));
+        }
+    }
+
+    req.inner.previous_response_id = normalized_previous_backend_id.clone();
+
+    let session_id = session_id.unwrap_or_else(|| format!("resp_{}", Uuid::new_v4().simple()));
+
+    let interpreter_requested = request_wants_code_interpreter(&req);
     let user_text = extract_user_text(&req);
 
     let mut response = call_responses_backend(&state.main_state, &req).await?;
 
-    let response_id = response.id.clone();
+    let backend_response_id = response.id.clone();
     let model_used = response.model.clone();
 
     let mut session = if let Some(mut session) = existing_session {
@@ -126,7 +153,7 @@ async fn responses_handler_impl(
         session
     } else {
         Session::new(
-            response_id.clone(),
+            session_id.clone(),
             model_used.clone(),
             req.upstream().instructions.clone(),
         )
@@ -137,19 +164,60 @@ async fn responses_handler_impl(
         session.add_message("user".to_string(), text, user_tokens, None, None);
     }
 
-    if let Some(assistant_text) = extract_assistant_text(&response) {
+    let assistant_text = extract_assistant_text(&response);
+    if let Some(ref text) = assistant_text {
         session.add_message(
             "assistant".to_string(),
-            assistant_text,
+            text.clone(),
             response.usage.output_tokens,
             None,
-            Some(response_id.clone()),
+            Some(backend_response_id.clone()),
         );
+    }
+
+    if interpreter_requested {
+        if let Some(service) = state.interpreter() {
+            if let Some(code_block) = assistant_text
+                .as_deref()
+                .and_then(extract_python_code_block)
+            {
+                match service.execute(&session.session_id, &code_block).await {
+                    Ok(result) => {
+                        let summary = format_execution_result(&result);
+                        session.add_message("tool".to_string(), summary.clone(), 0, None, None);
+                        attach_interpreter_output(&mut response, &summary);
+                        response
+                            .metadata
+                            .insert("code_interpreter".to_string(), "executed".to_string());
+                    }
+                    Err(err) => warnings.push(format!("Code interpreter failed: {err}")),
+                }
+            } else if assistant_text.is_some() {
+                warnings.push(
+                    "Code interpreter requested but no Python code block was returned".to_string(),
+                );
+            } else {
+                warnings.push(
+                    "Code interpreter requested but downstream returned no assistant text"
+                        .to_string(),
+                );
+            }
+        } else {
+            warnings.push(
+                "`tool_resources.code_interpreter` requested but interpreter is disabled"
+                    .to_string(),
+            );
+        }
     }
 
     update_session_extended_data(&mut session, &req);
 
     db.save_session(&session).await?;
+
+    response.id = session_id.clone();
+    if client_previous_response_id.is_some() {
+        response.previous_response_id = client_previous_response_id;
+    }
 
     apply_warnings(&mut response, &mut warnings);
 
@@ -334,6 +402,78 @@ fn apply_warnings(response: &mut ResponseReply, warnings: &mut Vec<String>) {
     }
 }
 
+fn request_wants_code_interpreter(req: &ResponseRequest) -> bool {
+    req.tool_resources
+        .as_ref()
+        .and_then(|resources| resources.code_interpreter.as_ref())
+        .is_some()
+}
+
+fn extract_python_code_block(text: &str) -> Option<String> {
+    for marker in ["```python", "```py"] {
+        if let Some(start) = text.find(marker) {
+            let code_start = start + marker.len();
+            if let Some(end) = text[code_start..].find("```") {
+                let snippet = text[code_start..code_start + end].trim();
+                if !snippet.is_empty() {
+                    return Some(snippet.to_string());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn attach_interpreter_output(response: &mut ResponseReply, text: &str) {
+    let message_id = format!("msg_tool_{}", Uuid::new_v4().simple());
+    let content = ResponseOutputItemOutputMessageContent::OutputText {
+        annotations: Vec::new(),
+        text: text.to_string(),
+        ty: "output_text".to_string(),
+        logprobs: None,
+    };
+
+    response.output.push(ResponseOutputItem::OutputMessage {
+        content: vec![content],
+        id: message_id,
+        role: "assistant".to_string(),
+        status: "completed".to_string(),
+        ty: "message".to_string(),
+    });
+}
+
+fn format_execution_result(result: &ExecutionResult) -> String {
+    let mut sections = vec![format!("exit_code: {}", result.exit_code)];
+
+    if !result.stdout.trim().is_empty() {
+        sections.push(format!(
+            "stdout:\n{}",
+            truncate_output(result.stdout.trim())
+        ));
+    }
+
+    if !result.stderr.trim().is_empty() {
+        sections.push(format!(
+            "stderr:\n{}",
+            truncate_output(result.stderr.trim())
+        ));
+    }
+
+    sections.join("\n\n")
+}
+
+fn truncate_output(text: &str) -> String {
+    if text.chars().count() <= INTERPRETER_OUTPUT_LIMIT {
+        return text.to_string();
+    }
+
+    text.chars()
+        .take(INTERPRETER_OUTPUT_LIMIT - 1)
+        .collect::<String>()
+        + "…"
+}
+
 fn validate_request(req: &ResponseRequest) -> Result<Vec<String>, ResponseError> {
     let mut warnings = Vec::new();
     let inner = req.upstream();
@@ -455,7 +595,8 @@ fn validate_request(req: &ResponseRequest) -> Result<Vec<String>, ResponseError>
         warnings.push("`reasoning` ignored: reasoning traces not yet supported".to_string());
     }
 
-    if req.tool_resources.is_some() {
+    let code_interpreter_requested = request_wants_code_interpreter(req);
+    if req.tool_resources.is_some() && !code_interpreter_requested {
         warnings.push(
             "`tool_resources` ignored: tool calling is not enabled for text responses".to_string(),
         );
@@ -690,5 +831,28 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("response_format")));
         assert!(warnings.iter().any(|w| w.contains("reasoning")));
         assert!(warnings.iter().any(|w| w.contains("user")));
+    }
+
+    #[test]
+    fn test_extract_python_code_block() {
+        let snippet = "Here is code:\n```python\nprint('hello')\n```";
+        assert_eq!(
+            extract_python_code_block(snippet),
+            Some("print('hello')".to_string())
+        );
+        assert!(extract_python_code_block("no code here").is_none());
+    }
+
+    #[test]
+    fn test_format_execution_result() {
+        let result = ExecutionResult {
+            stdout: "1\n2".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+        };
+        let formatted = format_execution_result(&result);
+        assert!(formatted.contains("exit_code: 0"));
+        assert!(formatted.contains("stdout"));
+        assert!(formatted.contains("1"));
     }
 }

--- a/src/responses/mod.rs
+++ b/src/responses/mod.rs
@@ -1,3 +1,4 @@
+pub mod code_interpreter;
 pub mod db;
 pub mod handlers;
 pub mod models;

--- a/src/responses/models.rs
+++ b/src/responses/models.rs
@@ -109,9 +109,12 @@ pub use endpoints::responses::{
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Session {
-    pub response_id: String,
+    /// Nexus-managed identifier that callers pass back via previous_response_id
+    pub session_id: String,
     pub created: i64,
     pub model_used: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_backend_response_id: Option<String>,
     pub messages: Vec<SessionMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extended_data: Option<serde_json::Value>,
@@ -137,7 +140,7 @@ pub struct SessionRow {
 }
 
 impl Session {
-    pub fn new(response_id: String, model: String, instructions: Option<String>) -> Self {
+    pub fn new(session_id: String, model: String, instructions: Option<String>) -> Self {
         let now = chrono::Utc::now().timestamp();
         let mut messages = Vec::new();
 
@@ -153,9 +156,10 @@ impl Session {
         }
 
         Session {
-            response_id,
+            session_id,
             created: now,
             model_used: model,
+            last_backend_response_id: None,
             messages,
             extended_data: None,
         }
@@ -178,6 +182,10 @@ impl Session {
             response_time,
             response_id,
         });
+
+        if let Some(resp_id) = self.messages.last().and_then(|msg| msg.response_id.clone()) {
+            self.last_backend_response_id = Some(resp_id);
+        }
     }
 
     #[allow(dead_code)]
@@ -194,6 +202,17 @@ impl Session {
     #[allow(dead_code)]
     pub fn total_tokens(&self) -> u64 {
         self.messages.iter().map(|msg| msg.tokens).sum()
+    }
+
+    pub fn latest_backend_response_id(&self) -> Option<String> {
+        if let Some(id) = &self.last_backend_response_id {
+            return Some(id.clone());
+        }
+
+        self.messages
+            .iter()
+            .rev()
+            .find_map(|msg| msg.response_id.clone())
     }
 }
 
@@ -229,6 +248,10 @@ mod tests {
         assert_eq!(assistant_msg.tokens, 10);
         assert_eq!(assistant_msg.response_time, Some(150));
         assert_eq!(assistant_msg.response_id, Some("resp_123".to_string()));
+        assert_eq!(
+            session.last_backend_response_id,
+            Some("resp_123".to_string())
+        );
     }
 
     #[test]
@@ -279,6 +302,21 @@ mod tests {
         assert_eq!(
             history[3],
             ("user".to_string(), "Second message".to_string())
+        );
+
+        assert_eq!(session.latest_backend_response_id(), None);
+
+        session.add_message(
+            "assistant".to_string(),
+            "Final".to_string(),
+            4,
+            None,
+            Some("resp_999".to_string()),
+        );
+
+        assert_eq!(
+            session.latest_backend_response_id(),
+            Some("resp_999".to_string())
         );
     }
 }


### PR DESCRIPTION
## Summary

- [x] Docker-based code interpreter for /responses, and new [code_interpreter] config
- [x] Execute python blocks inside sandboxed containers and then stdout/stderr as tool output
- [x] Persist interpreter metadata with sessions, multi-turn conversations can reuse the container

Closes #11
Related to WasmEdge/WasmEdge#4374